### PR TITLE
Remove tracked build binary and dead go generate hook

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -304,6 +304,7 @@ $RECYCLE.BIN/
 
 # Project-specific build artifacts
 bin/
+build/
 dist/
 
 # Mage-managed directories

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -7,7 +7,6 @@ project_name: pre-commit
 before:
   hooks:
   - go mod tidy
-  - go generate ./...
 
 builds:
 - id: pre-commit


### PR DESCRIPTION
## Summary

- Remove `build/pre-commit` binary from git tracking and add `build/` to `.gitignore`
- Remove no-op `go generate ./...` hook from `.goreleaser.yaml` (no `//go:generate` directives exist in the codebase)

## Test plan

- [x] `make build` still works (binary goes to `build/` which is now gitignored)
- [x] `git status` no longer shows `build/pre-commit` as modified

🤖 Generated with [Claude Code](https://claude.com/claude-code)