### PR TITLE
docs: add MIT license and update documentation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,7 +6,7 @@ Thanks for your interest in contributing! This guide covers development setup, w
 
 ### Prerequisites
 
-- Go 1.25+
+- Go 1.25.7+
 - [golangci-lint](https://golangci-lint.run/welcome/install/) (for linting)
 
 ### Building

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Blair Hamilton
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ A Go reimplementation of [pre-commit](https://github.com/pre-commit/pre-commit) 
 ## Features
 
 - **Drop-in replacement** — identical CLI interface to the Python pre-commit tool
-- **21 supported languages**: Python, Node, Go, Ruby, Rust, Docker, Docker Image, Conda, Coursier, Dart, Dotnet, Haskell, Julia, Lua, Perl, R, Swift, Fail, Pygrep, System, Script
+- **22 supported languages**: Python, Node, Go, Ruby, Rust, Docker, Docker Image, Conda, Coursier, Dart, Dotnet, Haskell, Julia, Lua, Perl, R, Swift, Fail, Pygrep, System, Script, Python venv
 - **All hook types**: pre-commit, pre-merge-commit, pre-push, commit-msg, post-checkout, post-commit, post-merge, post-rewrite, prepare-commit-msg, pre-rebase
 - **File type identification** by extension, filename, and shebang
 - **Parallel hook execution** with xargs-style batching
@@ -139,4 +139,4 @@ CI will build cross-platform binaries and attach them to the GitHub release. See
 
 ## License
 
-MIT
+[MIT](LICENSE)


### PR DESCRIPTION
## Summary

- Add `LICENSE` file with MIT license (Copyright 2026 Blair Hamilton)
- Update README to link to LICENSE file instead of bare "MIT" text
- Fix language count from 21 to 22 (Python venv was missing from the list)
- Pin Go version in CONTRIBUTING.md to 1.25.7+ to match go.mod

## Test plan

- [x] No code changes — docs only
- [ ] Verify LICENSE renders correctly on GitHub repo page

🤖 Generated with [Claude Code](https://claude.com/claude-code)