### PR TITLE
chore: update parity report with clean command regression

### DIFF
--- a/test/integration/parity_report.json
+++ b/test/integration/parity_report.json
@@ -1,9 +1,9 @@
 {
-  "generated": "2026-04-10T09:01:39-04:00",
+  "generated": "2026-04-10T10:11:39-04:00",
   "total": 76,
-  "pass": 76,
-  "fail": 0,
-  "parity": "100.0%",
+  "pass": 75,
+  "fail": 1,
+  "parity": "98.7%",
   "results": [
     {
       "command": "--version",
@@ -216,9 +216,9 @@
       "command": "clean",
       "category": "exit code",
       "test": "exits 0",
-      "py_exit": 0,
+      "py_exit": 3,
       "go_exit": 0,
-      "match": true
+      "match": false
     },
     {
       "command": "gc",


### PR DESCRIPTION
## Summary
- Updated integration parity report to reflect current test results
- The `clean` command now has a parity mismatch: Python exits 3 while Go exits 0
- Overall parity dropped from 100.0% (76/76) to 98.7% (75/76)

## Test plan
- [ ] Investigate why Python `clean` now exits 3
- [ ] Determine if Go should match the new Python behavior or if this is a Python regression

🤖 Generated with [Claude Code](https://claude.com/claude-code)