### PR TITLE
fix: skip non-existent files and sanitize GIT_* env vars

### DIFF
--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -20,9 +20,9 @@ import (
 // See https://github.com/pre-commit/pre-commit/issues/300
 func NoGitEnv() []string {
 	allowed := map[string]bool{
-		"GIT_EXEC_PATH":              true,
-		"GIT_SSH":                    true,
-		"GIT_SSH_COMMAND":            true,
+		"GIT_EXEC_PATH":             true,
+		"GIT_SSH":                   true,
+		"GIT_SSH_COMMAND":           true,
 		"GIT_SSL_CAINFO":            true,
 		"GIT_SSL_NO_VERIFY":         true,
 		"GIT_CONFIG_COUNT":          true,

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -10,9 +10,41 @@ import (
 	"strings"
 )
 
+// NoGitEnv returns the current environment with GIT_* variables removed
+// (except for a safe allowlist). This matches the Python pre-commit's
+// no_git_env() which prevents many subtle bugs:
+//   - GIT_DIR: causes git clone to clone wrong thing
+//   - GIT_INDEX_FILE: causes 'error invalid object' during commit
+//   - GIT_WORK_TREE: exported by some git versions during hook execution
+//
+// See https://github.com/pre-commit/pre-commit/issues/300
+func NoGitEnv() []string {
+	allowed := map[string]bool{
+		"GIT_EXEC_PATH":              true,
+		"GIT_SSH":                    true,
+		"GIT_SSH_COMMAND":            true,
+		"GIT_SSL_CAINFO":            true,
+		"GIT_SSL_NO_VERIFY":         true,
+		"GIT_CONFIG_COUNT":          true,
+		"GIT_HTTP_PROXY_AUTHMETHOD": true,
+		"GIT_ALLOW_PROTOCOL":        true,
+		"GIT_ASKPASS":               true,
+	}
+	var env []string
+	for _, e := range os.Environ() {
+		k, _, _ := strings.Cut(e, "=")
+		if strings.HasPrefix(k, "GIT_") && !allowed[k] && !strings.HasPrefix(k, "GIT_CONFIG_KEY_") && !strings.HasPrefix(k, "GIT_CONFIG_VALUE_") {
+			continue
+		}
+		env = append(env, e)
+	}
+	return env
+}
+
 // CmdOutput runs a git command and returns its stdout.
 func CmdOutput(args ...string) (string, error) {
 	cmd := exec.Command("git", args...)
+	cmd.Env = NoGitEnv()
 	var stdout, stderr bytes.Buffer
 	cmd.Stdout = &stdout
 	cmd.Stderr = &stderr
@@ -26,6 +58,7 @@ func CmdOutput(args ...string) (string, error) {
 func CmdOutputInDir(dir string, args ...string) (string, error) {
 	cmd := exec.Command("git", args...)
 	cmd.Dir = dir
+	cmd.Env = NoGitEnv()
 	var stdout, stderr bytes.Buffer
 	cmd.Stdout = &stdout
 	cmd.Stderr = &stderr
@@ -304,20 +337,6 @@ func GetHooksDir(root ...string) (string, error) {
 		return "", err
 	}
 	return filepath.Join(gitDir, "hooks"), nil
-}
-
-// NoGitEnv returns the current environment with all GIT_* variables removed.
-// This matches Python's no_git_env() which strips git-specific vars to avoid
-// interference when running hooks.
-func NoGitEnv() []string {
-	var env []string
-	for _, e := range os.Environ() {
-		parts := strings.SplitN(e, "=", 2)
-		if len(parts) >= 1 && !strings.HasPrefix(parts[0], "GIT_") {
-			env = append(env, e)
-		}
-	}
-	return env
 }
 
 // IntentToAddFiles returns files that were added with --intent-to-add.

--- a/internal/git/git_test.go
+++ b/internal/git/git_test.go
@@ -46,17 +46,24 @@ func initTestRepo(t *testing.T) string {
 // --- NoGitEnv tests ---
 
 func TestNoGitEnv(t *testing.T) {
-	// Set some GIT_ env vars.
+	// Set some GIT_ env vars that should be stripped.
 	t.Setenv("GIT_DIR", "/some/path")
 	t.Setenv("GIT_WORK_TREE", "/other/path")
 	t.Setenv("GIT_AUTHOR_NAME", "test")
+	t.Setenv("GIT_INDEX_FILE", "/index")
 
 	env := NoGitEnv()
 
+	stripped := map[string]bool{
+		"GIT_DIR":         true,
+		"GIT_WORK_TREE":  true,
+		"GIT_AUTHOR_NAME": true,
+		"GIT_INDEX_FILE":  true,
+	}
 	for _, e := range env {
 		name := strings.SplitN(e, "=", 2)[0]
-		if strings.HasPrefix(name, "GIT_") {
-			t.Errorf("NoGitEnv should strip GIT_ vars, found %s", name)
+		if stripped[name] {
+			t.Errorf("NoGitEnv should strip %s but it was preserved", name)
 		}
 	}
 
@@ -70,6 +77,36 @@ func TestNoGitEnv(t *testing.T) {
 	}
 	if !hasPath {
 		t.Error("expected non-GIT_ vars to be preserved")
+	}
+}
+
+func TestNoGitEnv_AllowedVars(t *testing.T) {
+	// Allowed GIT_ vars should be preserved.
+	t.Setenv("GIT_SSH", "ssh-custom")
+	t.Setenv("GIT_SSH_COMMAND", "ssh -o Opt=val")
+	t.Setenv("GIT_EXEC_PATH", "/usr/lib/git")
+	t.Setenv("GIT_CONFIG_KEY_0", "user.name")
+	t.Setenv("GIT_CONFIG_VALUE_0", "test")
+
+	env := NoGitEnv()
+
+	allowed := map[string]bool{
+		"GIT_SSH":            false,
+		"GIT_SSH_COMMAND":    false,
+		"GIT_EXEC_PATH":     false,
+		"GIT_CONFIG_KEY_0":   false,
+		"GIT_CONFIG_VALUE_0": false,
+	}
+	for _, e := range env {
+		name := strings.SplitN(e, "=", 2)[0]
+		if _, ok := allowed[name]; ok {
+			allowed[name] = true
+		}
+	}
+	for name, found := range allowed {
+		if !found {
+			t.Errorf("NoGitEnv should preserve allowed var %s", name)
+		}
 	}
 }
 
@@ -313,6 +350,61 @@ func TestGetStagedFiles_WithStaged(t *testing.T) {
 	}
 	if len(files) != 1 || files[0] != "new.txt" {
 		t.Errorf("expected [new.txt], got %v", files)
+	}
+}
+
+func TestGetStagedFiles_ExcludesDeleted(t *testing.T) {
+	dir := initTestRepo(t)
+
+	old, _ := os.Getwd()
+	defer os.Chdir(old)
+	os.Chdir(dir)
+
+	run := func(args ...string) {
+		t.Helper()
+		cmd := exec.Command("git", args...)
+		cmd.Dir = dir
+		cmd.Env = append(os.Environ(),
+			"GIT_AUTHOR_NAME=Test",
+			"GIT_AUTHOR_EMAIL=test@test.com",
+			"GIT_COMMITTER_NAME=Test",
+			"GIT_COMMITTER_EMAIL=test@test.com",
+		)
+		out, err := cmd.CombinedOutput()
+		if err != nil {
+			t.Fatalf("git %s failed: %v\n%s", strings.Join(args, " "), err, out)
+		}
+	}
+
+	// Create and commit a second file.
+	if err := os.WriteFile(filepath.Join(dir, "delete-me.yaml"), []byte("test: content\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	run("add", "delete-me.yaml")
+	run("commit", "-m", "add file to delete")
+
+	// Stage deletion of the file.
+	run("rm", "delete-me.yaml")
+
+	// Also stage a modification to another file.
+	if err := os.WriteFile(filepath.Join(dir, "README.md"), []byte("modified\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	run("add", "README.md")
+
+	files, err := GetStagedFiles()
+	if err != nil {
+		t.Fatalf("GetStagedFiles failed: %v", err)
+	}
+
+	// Should only contain README.md, not delete-me.yaml.
+	for _, f := range files {
+		if f == "delete-me.yaml" {
+			t.Error("GetStagedFiles should not include deleted files")
+		}
+	}
+	if len(files) != 1 || files[0] != "README.md" {
+		t.Errorf("expected [README.md], got %v", files)
 	}
 }
 

--- a/internal/git/git_test.go
+++ b/internal/git/git_test.go
@@ -56,7 +56,7 @@ func TestNoGitEnv(t *testing.T) {
 
 	stripped := map[string]bool{
 		"GIT_DIR":         true,
-		"GIT_WORK_TREE":  true,
+		"GIT_WORK_TREE":   true,
 		"GIT_AUTHOR_NAME": true,
 		"GIT_INDEX_FILE":  true,
 	}
@@ -93,7 +93,7 @@ func TestNoGitEnv_AllowedVars(t *testing.T) {
 	allowed := map[string]bool{
 		"GIT_SSH":            false,
 		"GIT_SSH_COMMAND":    false,
-		"GIT_EXEC_PATH":     false,
+		"GIT_EXEC_PATH":      false,
 		"GIT_CONFIG_KEY_0":   false,
 		"GIT_CONFIG_VALUE_0": false,
 	}

--- a/internal/hook/hook_test.go
+++ b/internal/hook/hook_test.go
@@ -1,6 +1,7 @@
 package hook
 
 import (
+	"os"
 	"strings"
 	"testing"
 
@@ -801,4 +802,32 @@ func TestFromManifestHook(t *testing.T) {
 			t.Errorf("Types = %v, want empty (TypesOr is set)", h.Types)
 		}
 	})
+}
+
+// ---------------------------------------------------------------------------
+// filterFiles
+// ---------------------------------------------------------------------------
+
+func TestFilterFiles_SkipsNonExistentFiles(t *testing.T) {
+	// Create a real file.
+	dir := t.TempDir()
+	realFile := dir + "/exists.yaml"
+	if err := os.WriteFile(realFile, []byte("key: value\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	ghostFile := dir + "/ghost.yaml"
+
+	h := &Hook{
+		Types: []string{"file"},
+	}
+
+	result := filterFiles([]string{realFile, ghostFile}, h)
+
+	if len(result) != 1 {
+		t.Fatalf("expected 1 file, got %d: %v", len(result), result)
+	}
+	if result[0] != realFile {
+		t.Errorf("expected %q, got %q", realFile, result[0])
+	}
 }

--- a/internal/hook/runner.go
+++ b/internal/hook/runner.go
@@ -200,7 +200,6 @@ func (r *Runner) Run(ctx context.Context, opts RunOptions) RunResult {
 		var exitCode int
 		var hookOutput []byte
 		exitCode, hookOutput, err = runHookXargs(ctx, lang, h, fileArgs, r.root)
-
 		if err != nil {
 			output.PrintHookHeader(h.Name, output.ResultError)
 			output.Error("hook execution error: %v", err)
@@ -343,6 +342,13 @@ func filterFiles(files []string, h *Hook) []string {
 	}
 
 	for _, f := range files {
+		// Skip files that do not exist on disk (e.g. staged deletions
+		// or files removed from the working tree without git rm).
+		// Matches Python identify library which raises ValueError for
+		// non-existent paths.
+		if _, err := os.Lstat(f); err != nil {
+			continue
+		}
 		// Check include pattern.
 		if includeRe != nil && !pcre.Match(includeRe, f) {
 			continue


### PR DESCRIPTION
## Problem

Hooks were receiving deleted files (e.g. files staged for deletion or removed from the working tree without `git rm`) causing `FileNotFoundError` in Python-based hooks like `end-of-file-fixer`, `trailing-whitespace`, and `check-yaml`:

```
FileNotFoundError: [Errno 2] No such file or directory: 'aws/accounts/testing.yaml'
```

## Root Cause

The Go `identify.TagsForFile()` silently tags non-existent files as `text` + extension-based tags (because `isBinaryFile()` returns `false` when it can't open the file). The Python `identify` library raises `ValueError` for non-existent paths. This meant ghost files passed through type matching and reached hooks.

## Fixes

### 1. Skip non-existent files in `filterFiles` (`runner.go`)

Added an `os.Lstat()` check before processing each file, so files that don't exist on disk are filtered out before being passed to hooks. This matches the Python `identify` library's behavior.

### 2. Improved `NoGitEnv()` allowlist (`git.go`)

Updated `NoGitEnv()` to use an allowlist matching the Python pre-commit's `no_git_env()` implementation, preserving safe vars like `GIT_SSH`, `GIT_EXEC_PATH`, `GIT_CONFIG_KEY_*`, etc. Applied this to `CmdOutput` and `CmdOutputInDir` to prevent subtle bugs from leaked `GIT_DIR`, `GIT_INDEX_FILE`, `GIT_WORK_TREE`, etc.

See: https://github.com/pre-commit/pre-commit/issues/300

## Tests

- `TestFilterFiles_SkipsNonExistentFiles` — verifies non-existent files are excluded
- `TestGetStagedFiles_ExcludesDeleted` — verifies `git rm`'d files aren't returned
- `TestNoGitEnv` / `TestNoGitEnv_AllowedVars` — verifies env sanitization with allowlist