### PR TITLE
feat: add dedicated release workflow with goreleaser

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,8 +8,6 @@ on:
     branches: [ main ]
   pull_request:
     branches: [ main ]
-  release:
-    types: [ created ]
 
 jobs:
   test:
@@ -59,32 +57,6 @@ jobs:
 
     - name: Build
       run: make build
-
-  release:
-    runs-on: ubuntu-latest
-    needs: [ test, lint, build ]
-    if: github.event_name == 'release'
-    permissions:
-      contents: write
-    steps:
-    - uses: actions/checkout@v4
-      with:
-        fetch-depth: 0
-
-    - name: Set up Go
-      uses: actions/setup-go@v5
-      with:
-        go-version: ${{ env.GO_VERSION }}
-        cache: true
-
-    - name: Run GoReleaser
-      uses: goreleaser/goreleaser-action@v6
-      with:
-        distribution: goreleaser
-        version: latest
-        args: release --clean
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   language-integration:
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,48 @@
+name: Release
+
+on:
+  push:
+    tags:
+    - "v*"
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Tag to release (e.g. v1.0.0). Must already exist."
+        required: true
+        type: string
+
+permissions:
+  contents: write
+
+env:
+  GO_VERSION: "1.26"
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+
+    - name: Set up Go
+      uses: actions/setup-go@v5
+      with:
+        go-version: ${{ env.GO_VERSION }}
+        cache: true
+
+    - name: Checkout tag (workflow_dispatch)
+      if: github.event_name == 'workflow_dispatch'
+      run: git checkout "refs/tags/${{ inputs.tag }}"
+
+    - name: Run tests
+      run: make test
+
+    - name: Run GoReleaser
+      uses: goreleaser/goreleaser-action@v6
+      with:
+        distribution: goreleaser
+        version: latest
+        args: release --clean
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

Add a dedicated release workflow and clean up CI.

### Changes
- **New** `.github/workflows/release.yml` — triggered by tag push (`v*`) and `workflow_dispatch` (manual tag input)
- **Modified** `.github/workflows/ci.yml` — removed the release trigger and release job (moved to dedicated workflow)

### Release workflow steps
1. Checkout with full history
2. Set up Go
3. On `workflow_dispatch`, checkout the specified tag
4. Run tests
5. Run GoReleaser to build and publish the release