### PR TITLE
fix: update goreleaser config to remove deprecated properties

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,7 +42,7 @@ jobs:
       uses: goreleaser/goreleaser-action@v7
       with:
         distribution: goreleaser
-        version: latest
+        version: "~> v2"
         args: release --clean
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -28,19 +28,21 @@ builds:
 
 archives:
 - id: default
-  format: tar.gz
+  formats:
+  - tar.gz
   # this name template makes the OS and Arch compatible with the results of uname.
   name_template: >-
     {{ .ProjectName }}_ {{- title .Os }}_ {{- if eq .Arch "amd64" }}x86_64 {{- else if eq .Arch "386" }}i386 {{- else }}{{ .Arch }}{{ end }} {{- if .Arm }}v{{ .Arm }}{{ end }}
   format_overrides:
   - goos: windows
-    format: zip
+    formats:
+    - zip
 
 checksum:
   name_template: 'checksums.txt'
 
 snapshot:
-  name_template: "{{ incpatch .Version }}-next"
+  version_template: "{{ incpatch .Version }}-next"
 
 changelog:
   sort: asc


### PR DESCRIPTION
Fixes the release workflow failure caused by deprecated GoReleaser v2 config properties.

## Changes

- `archives.format` → `archives.formats` (now a list)
- `archives.format_overrides.format` → `archives.format_overrides.formats` (now a list)
- `snapshot.name_template` → `snapshot.version_template`
- Pin goreleaser version to `~> v2` instead of `latest` to avoid future breakage

Validated locally with `goreleaser check` — config now passes cleanly.