### PR TITLE
fix: use platform-specific file locking for Windows compatibility

### DIFF
--- a/internal/store/lock_unix.go
+++ b/internal/store/lock_unix.go
@@ -1,0 +1,16 @@
+//go:build !windows
+
+package store
+
+import (
+	"os"
+	"syscall"
+)
+
+func lockFile(f *os.File) error {
+	return syscall.Flock(int(f.Fd()), syscall.LOCK_EX)
+}
+
+func unlockFile(f *os.File) error {
+	return syscall.Flock(int(f.Fd()), syscall.LOCK_UN)
+}

--- a/internal/store/lock_windows.go
+++ b/internal/store/lock_windows.go
@@ -1,0 +1,53 @@
+//go:build windows
+
+package store
+
+import (
+	"os"
+	"syscall"
+	"unsafe"
+)
+
+var (
+	modkernel32      = syscall.NewLazyDLL("kernel32.dll")
+	procLockFileEx   = modkernel32.NewProc("LockFileEx")
+	procUnlockFileEx = modkernel32.NewProc("UnlockFileEx")
+)
+
+const (
+	lockfileExclusiveLock = 0x00000002
+	lockfileFailImmediately = 0x00000001
+)
+
+func lockFile(f *os.File) error {
+	h := syscall.Handle(f.Fd())
+	ol := new(syscall.Overlapped)
+	r1, _, err := procLockFileEx.Call(
+		uintptr(h),
+		uintptr(lockfileExclusiveLock),
+		0,
+		1,
+		0,
+		uintptr(unsafe.Pointer(ol)),
+	)
+	if r1 == 0 {
+		return err
+	}
+	return nil
+}
+
+func unlockFile(f *os.File) error {
+	h := syscall.Handle(f.Fd())
+	ol := new(syscall.Overlapped)
+	r1, _, err := procUnlockFileEx.Call(
+		uintptr(h),
+		0,
+		1,
+		0,
+		uintptr(unsafe.Pointer(ol)),
+	)
+	if r1 == 0 {
+		return err
+	}
+	return nil
+}

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -292,7 +292,7 @@ func (s *Store) acquireLock() (func(), error) {
 	}
 
 	return func() {
-		unlockFile(lf)
+		_ = unlockFile(lf)
 		lf.Close()
 	}, nil
 }

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -8,7 +8,6 @@ import (
 	"os"
 	"path/filepath"
 	"sync"
-	"syscall"
 
 	gitutil "github.com/blairham/go-pre-commit/internal/git"
 )
@@ -281,19 +280,19 @@ func (s *Store) acquireLock() (func(), error) {
 		return nil, err
 	}
 
-	lockFile, err := os.OpenFile(s.lockPath(), os.O_CREATE|os.O_RDWR, 0o644)
+	lf, err := os.OpenFile(s.lockPath(), os.O_CREATE|os.O_RDWR, 0o644)
 	if err != nil {
 		return nil, fmt.Errorf("failed to open lock file: %w", err)
 	}
 
-	// Use flock for advisory locking.
-	if err := syscall.Flock(int(lockFile.Fd()), syscall.LOCK_EX); err != nil {
-		lockFile.Close()
+	// Use platform-specific file locking.
+	if err := lockFile(lf); err != nil {
+		lf.Close()
 		return nil, fmt.Errorf("failed to acquire lock: %w", err)
 	}
 
 	return func() {
-		syscall.Flock(int(lockFile.Fd()), syscall.LOCK_UN)
-		lockFile.Close()
+		unlockFile(lf)
+		lf.Close()
 	}, nil
 }


### PR DESCRIPTION
The Windows build fails because `syscall.Flock` and `syscall.LOCK_EX`/`LOCK_UN` are Unix-only.

## Changes
- Extract file locking into platform-specific files using build tags
- `lock_unix.go`: Uses `syscall.Flock` (existing behavior)
- `lock_windows.go`: Uses `LockFileEx`/`UnlockFileEx` via `kernel32.dll`
- Remove `syscall` import from `store.go`

## Verified
- `GOOS=linux GOARCH=amd64 go build ./...` ✓
- `GOOS=darwin GOARCH=arm64 go build ./...` ✓
- `GOOS=windows GOARCH=amd64 go build ./...` ✓
- `make test` ✓ (100% parity)