### PR TITLE
feat: add grouped changelog with conventional commit categories

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -46,10 +46,21 @@ snapshot:
 
 changelog:
   sort: asc
+  use: github
+  groups:
+  - title: Features
+    regexp: '^.*?feat(\([[:word:]]+\))??!?:.+$'
+    order: 0
+  - title: Bug Fixes
+    regexp: '^.*?fix(\([[:word:]]+\))??!?:.+$'
+    order: 1
+  - title: Other
+    order: 999
   filters:
     exclude:
     - '^docs:'
     - '^test:'
+    - '^chore:'
 
 release:
   draft: false

--- a/internal/store/lock_windows.go
+++ b/internal/store/lock_windows.go
@@ -16,7 +16,6 @@ var (
 
 const (
 	lockfileExclusiveLock = 0x00000002
-	lockfileFailImmediately = 0x00000001
 )
 
 func lockFile(f *os.File) error {


### PR DESCRIPTION
Adds grouped changelog generation to goreleaser so release notes are organized by commit type.

## Changes
- Use GitHub commit data (`use: github`) for accurate inter-tag diffs
- Group commits into **Features** (`feat:`), **Bug Fixes** (`fix:`), and **Other**
- Exclude `docs:`, `test:`, and `chore:` commits from release notes