### PR TITLE
feat: close remaining Python pre-commit parity gaps

### DIFF
--- a/internal/cli/autoupdate.go
+++ b/internal/cli/autoupdate.go
@@ -25,6 +25,7 @@ type autoupdateFlags struct {
 	Freeze       bool     `long:"freeze" description:"Store the current commit SHA alongside the tag as rev."`
 	Repo         []string `long:"repo" description:"Only update this repository. May be specified multiple times."`
 	Jobs         int      `short:"j" long:"jobs" default:"1" description:"Number of threads to use."`
+	DryRun       bool     `long:"dry-run" description:"Show what would be updated without writing changes."`
 }
 
 func (c *AutoupdateCommand) Run(args []string) int {
@@ -129,7 +130,7 @@ func (c *AutoupdateCommand) Run(args []string) int {
 		changed = true
 	}
 
-	if changed {
+	if changed && !opts.DryRun {
 		if err := os.WriteFile(opts.Config, []byte(raw), 0o644); err != nil {
 			fmt.Fprintf(os.Stderr, "Error: failed to write config: %v\n", err)
 			return 1
@@ -151,6 +152,7 @@ Options:
       --freeze          Store the current commit SHA alongside the tag as rev.
       --repo=REPO       Only update this repository (may be repeated).
   -j, --jobs=N          Number of threads to use (default: 1).
+      --dry-run         Show what would be updated without writing changes.
   -c, --config=FILE     Path to alternate config file.
       --color=MODE      Whether to use color (auto, always, never).
 `)

--- a/internal/cli/try_repo.go
+++ b/internal/cli/try_repo.go
@@ -50,6 +50,7 @@ type tryRepoFlags struct {
 	RewriteCmd      string   `long:"rewrite-command" description:"Rewrite command for post-rewrite hook."`
 	PreRebaseUp     string   `long:"pre-rebase-upstream" description:"Upstream from which the series was forked."`
 	PreRebaseBranch string   `long:"pre-rebase-branch" description:"Branch being rebased."`
+	Jobs            int      `short:"j" long:"jobs" description:"Number of jobs to run in parallel."`
 }
 
 func (c *TryRepoCommand) Run(args []string) int {
@@ -183,6 +184,7 @@ func (c *TryRepoCommand) Run(args []string) int {
 		Verbose:                    opts.Verbose,
 		ShowDiff:                   opts.ShowDiffOnFail,
 		Color:                      opts.Color,
+		Jobs:                       opts.Jobs,
 		FromRef:                    opts.FromRef,
 		ToRef:                      opts.ToRef,
 		CommitMsgFilename:          opts.CommitMsgFn,
@@ -231,6 +233,7 @@ Options:
       --fail-fast                Stop running hooks after the first failure.
       --from-ref=REF             Ref to check revision changes.
       --to-ref=REF               Ref to check revision changes.
+  -j, --jobs=N                   Number of jobs to run in parallel.
   -c, --config=FILE              Path to alternate config file.
       --color=MODE               Whether to use color (auto, always, never).
 `)

--- a/internal/hook/runner.go
+++ b/internal/hook/runner.go
@@ -379,7 +379,7 @@ func runHookXargs(ctx context.Context, lang languages.Language, h *Hook, fileArg
 	// Determine batch size and concurrency.
 	maxJobs := 1
 	if !h.RequireSerial {
-		maxJobs = targetConcurrency(jobs)
+		maxJobs = targetConcurrency(jobs, len(fileArgs))
 	}
 
 	// Batch the file arguments.
@@ -449,19 +449,30 @@ func batchFileArgs(files []string, maxBatchSize int) [][]string {
 }
 
 // targetConcurrency returns the target number of parallel jobs.
-func targetConcurrency(jobs int) int {
+// Matches Python pre-commit: min(cpu_count, max(1, fileCount/4)) when jobs is unset.
+// An explicit jobs value overrides the file-count cap.
+func targetConcurrency(jobs, fileCount int) int {
 	if os.Getenv("PRE_COMMIT_NO_CONCURRENCY") != "" {
 		return 1
 	}
 	if jobs > 0 {
 		return jobs
 	}
-	if os.Getenv("TRAVIS") != "" {
-		return 2
-	}
 	n := runtime.NumCPU()
+	if os.Getenv("TRAVIS") != "" {
+		n = 2
+	}
 	if n < 1 {
 		n = 1
+	}
+	if fileCount > 0 {
+		capped := fileCount / 4
+		if capped < 1 {
+			capped = 1
+		}
+		if capped < n {
+			n = capped
+		}
 	}
 	return n
 }

--- a/internal/hook/runner_test.go
+++ b/internal/hook/runner_test.go
@@ -115,24 +115,54 @@ func TestFilterFiles(t *testing.T) {
 
 func TestTargetConcurrency(t *testing.T) {
 	t.Run("respects jobs parameter", func(t *testing.T) {
-		got := targetConcurrency(4)
+		got := targetConcurrency(4, 100)
 		if got != 4 {
-			t.Errorf("targetConcurrency(4) = %d, want 4", got)
+			t.Errorf("targetConcurrency(4, 100) = %d, want 4", got)
+		}
+	})
+
+	t.Run("explicit jobs ignores file-count cap", func(t *testing.T) {
+		got := targetConcurrency(8, 1)
+		if got != 8 {
+			t.Errorf("targetConcurrency(8, 1) = %d, want 8", got)
 		}
 	})
 
 	t.Run("zero jobs falls back to CPU count", func(t *testing.T) {
-		got := targetConcurrency(0)
+		got := targetConcurrency(0, 1000)
 		if got < 1 {
-			t.Errorf("targetConcurrency(0) = %d, want >= 1", got)
+			t.Errorf("targetConcurrency(0, 1000) = %d, want >= 1", got)
+		}
+	})
+
+	t.Run("zero jobs with no files returns CPU count", func(t *testing.T) {
+		got := targetConcurrency(0, 0)
+		if got < 1 {
+			t.Errorf("targetConcurrency(0, 0) = %d, want >= 1", got)
+		}
+	})
+
+	t.Run("file count caps concurrency at files/4", func(t *testing.T) {
+		// 1 file -> at most 1 worker.
+		if got := targetConcurrency(0, 1); got != 1 {
+			t.Errorf("targetConcurrency(0, 1) = %d, want 1", got)
+		}
+		// 3 files -> at most 1 worker (3/4 = 0, clamped to 1).
+		if got := targetConcurrency(0, 3); got != 1 {
+			t.Errorf("targetConcurrency(0, 3) = %d, want 1", got)
+		}
+		// 8 files -> at most min(cpu, 2) workers.
+		got := targetConcurrency(0, 8)
+		if got < 1 || got > 2 {
+			t.Errorf("targetConcurrency(0, 8) = %d, want in [1, 2]", got)
 		}
 	})
 
 	t.Run("NO_CONCURRENCY overrides everything", func(t *testing.T) {
 		t.Setenv("PRE_COMMIT_NO_CONCURRENCY", "1")
-		got := targetConcurrency(8)
+		got := targetConcurrency(8, 100)
 		if got != 1 {
-			t.Errorf("targetConcurrency(8) with NO_CONCURRENCY = %d, want 1", got)
+			t.Errorf("targetConcurrency(8, 100) with NO_CONCURRENCY = %d, want 1", got)
 		}
 	})
 }


### PR DESCRIPTION
## Summary

After an evidence-based audit against upstream [pre-commit/pre-commit](https://github.com/pre-commit/pre-commit), three real divergences remained. This PR closes them so the Go binary behaves identically to upstream for user-visible CLI interactions.

- **`autoupdate --dry-run`** — preview rev changes without rewriting `.pre-commit-config.yaml`.
- **Concurrency formula** — `targetConcurrency` now applies Python's `min(cpu_count, max(1, files/4))` cap when `--jobs` is unset, avoiding over-parallelization on small file lists. Explicit `-j` overrides the file-count cap.
- **`try-repo --jobs`** — adds the `-j/--jobs` flag (Python's `try-repo` shares the `run` flag surface).

## Test plan

- [x] `go build ./...` — clean
- [x] `go vet ./...` — clean
- [x] `go test -race ./internal/hook/ ./internal/cli/` — pass
- [x] New `TestTargetConcurrency` cases cover: explicit jobs, zero-jobs+files, zero-jobs+no-files, file-count cap (1/3/8 files), `PRE_COMMIT_NO_CONCURRENCY`
- [ ] Manual: `pre-commit autoupdate --dry-run` shows updates, leaves config untouched
- [ ] Manual: `pre-commit try-repo <repo> -j 4 --all-files` accepts flag

🤖 Generated with [Claude Code](https://claude.com/claude-code)