### PR TITLE
feat(cli): allow repeated -t/--hook-type for uninstall and init-templatedir

### DIFF
--- a/internal/cli/init_templatedir.go
+++ b/internal/cli/init_templatedir.go
@@ -16,8 +16,8 @@ type InitTemplateDirCommand struct {
 
 type initTemplateDirFlags struct {
 	GlobalFlags
-	HookType       string `short:"t" long:"hook-type" default:"pre-commit" description:"The hook type to install."`
-	NoAllowMissing bool   `long:"no-allow-missing-config" description:"Assume cloned repos should have a pre-commit config."`
+	HookTypes      []string `short:"t" long:"hook-type" description:"Which hook type to install. May be specified multiple times. (default: pre-commit)"`
+	NoAllowMissing bool     `long:"no-allow-missing-config" description:"Assume cloned repos should have a pre-commit config."`
 }
 
 func (c *InitTemplateDirCommand) Run(args []string) int {
@@ -34,22 +34,35 @@ func (c *InitTemplateDirCommand) Run(args []string) int {
 	}
 	templateDir := remaining[0]
 
+	typesToInstall := opts.HookTypes
+	if len(typesToInstall) == 0 {
+		typesToInstall = []string{"pre-commit"}
+	}
+	for _, ht := range typesToInstall {
+		if _, ok := hookTypes[ht]; !ok {
+			fmt.Fprintf(os.Stderr, "Error: unknown hook type: %s. Choose from: %s\n", ht, strings.Join(sortedHookTypes(), ", "))
+			return 1
+		}
+	}
+
 	hooksDir := filepath.Join(templateDir, "hooks")
 	if err := os.MkdirAll(hooksDir, 0o755); err != nil {
 		fmt.Fprintf(os.Stderr, "Error: failed to create hooks directory: %v\n", err)
 		return 1
 	}
 
-	hookFile := filepath.Join(hooksDir, opts.HookType)
-	installID := "pre-commit-" + opts.HookType
-	content := fmt.Sprintf(hookTemplate, installID, opts.Config, opts.HookType)
+	for _, ht := range typesToInstall {
+		hookFile := filepath.Join(hooksDir, ht)
+		installID := "pre-commit-" + ht
+		content := fmt.Sprintf(hookTemplate, installID, opts.Config, ht)
 
-	if err := os.WriteFile(hookFile, []byte(content), 0o755); err != nil {
-		fmt.Fprintf(os.Stderr, "Error: failed to write hook: %v\n", err)
-		return 1
+		if err := os.WriteFile(hookFile, []byte(content), 0o755); err != nil {
+			fmt.Fprintf(os.Stderr, "Error: failed to write hook: %v\n", err)
+			return 1
+		}
+
+		fmt.Printf("pre-commit installed at %s\n", hookFile)
 	}
-
-	fmt.Printf("pre-commit installed at %s\n", hookFile)
 
 	if opts.NoAllowMissing {
 		if _, err := os.Stat(opts.Config); os.IsNotExist(err) {
@@ -72,7 +85,7 @@ Usage: pre-commit init-templatedir [options] DIRECTORY
 
 Options:
 
-  -t, --hook-type=TYPE              The hook type to install (default: pre-commit).
+  -t, --hook-type=TYPE              The hook type to install. May be repeated. (default: pre-commit)
       --no-allow-missing-config    Assume cloned repos should have a pre-commit config.
   -c, --config=FILE            Path to alternate config file.
       --color=MODE             Whether to use color (auto, always, never).

--- a/internal/cli/install.go
+++ b/internal/cli/install.go
@@ -190,7 +190,7 @@ type UninstallCommand struct {
 
 type uninstallFlags struct {
 	GlobalFlags
-	HookType string `short:"t" long:"hook-type" default:"pre-commit" description:"The hook type to uninstall."`
+	HookTypes []string `short:"t" long:"hook-type" description:"Which hook type to uninstall. May be specified multiple times. (default: pre-commit)"`
 }
 
 func (c *UninstallCommand) Run(args []string) int {
@@ -207,39 +207,53 @@ func (c *UninstallCommand) Run(args []string) int {
 		return 1
 	}
 
-	hookFile := filepath.Join(hooksDir, opts.HookType)
-
-	// Check if hook exists.
-	content, err := os.ReadFile(hookFile)
-	if err != nil {
-		if os.IsNotExist(err) {
-			fmt.Printf("%s hook not found, no action taken.\n", opts.HookType)
-			return 0
-		}
-		fmt.Fprintf(os.Stderr, "Error: failed to read hook: %v\n", err)
-		return 1
+	typesToUninstall := opts.HookTypes
+	if len(typesToUninstall) == 0 {
+		typesToUninstall = []string{"pre-commit"}
 	}
 
-	if !isPreCommitHook(string(content)) {
-		fmt.Printf("%s is not a pre-commit hook, no action taken.\n", hookFile)
-		return 0
-	}
-
-	if err := os.Remove(hookFile); err != nil {
-		fmt.Fprintf(os.Stderr, "Error: failed to remove hook: %v\n", err)
-		return 1
-	}
-
-	// Restore legacy hook if it exists.
-	legacyFile := hookFile + ".legacy"
-	if _, err := os.Stat(legacyFile); err == nil {
-		if err := os.Rename(legacyFile, hookFile); err == nil {
-			output.Info("Restored previous hook to %s", hookFile)
+	for _, ht := range typesToUninstall {
+		if _, ok := hookTypes[ht]; !ok {
+			fmt.Fprintf(os.Stderr, "Error: unknown hook type: %s. Choose from: %s\n", ht, strings.Join(sortedHookTypes(), ", "))
+			return 1
 		}
 	}
 
-	fmt.Printf("pre-commit uninstalled from %s\n", hookFile)
-	return 0
+	exit := 0
+	for _, ht := range typesToUninstall {
+		hookFile := filepath.Join(hooksDir, ht)
+		content, err := os.ReadFile(hookFile)
+		if err != nil {
+			if os.IsNotExist(err) {
+				fmt.Printf("%s does not exist, skipping.\n", ht)
+				continue
+			}
+			fmt.Fprintf(os.Stderr, "Error: failed to read hook: %v\n", err)
+			exit = 1
+			continue
+		}
+
+		if !isPreCommitHook(string(content)) {
+			fmt.Printf("%s is not a pre-commit hook, skipping.\n", hookFile)
+			continue
+		}
+
+		if err := os.Remove(hookFile); err != nil {
+			fmt.Fprintf(os.Stderr, "Error: failed to remove hook: %v\n", err)
+			exit = 1
+			continue
+		}
+
+		legacyFile := hookFile + ".legacy"
+		if _, err := os.Stat(legacyFile); err == nil {
+			if err := os.Rename(legacyFile, hookFile); err == nil {
+				output.Info("Restored previous hook to %s", hookFile)
+			}
+		}
+
+		fmt.Printf("pre-commit uninstalled from %s\n", hookFile)
+	}
+	return exit
 }
 
 func (c *UninstallCommand) Help() string {
@@ -250,7 +264,7 @@ Usage: pre-commit uninstall [options]
 
 Options:
 
-  -t, --hook-type=TYPE   The hook type to uninstall (default: pre-commit).
+  -t, --hook-type=TYPE   The hook type to uninstall. May be repeated. (default: pre-commit)
   -c, --config=FILE      Path to alternate config file.
       --color=MODE       Whether to use color (auto, always, never).
 `)


### PR DESCRIPTION
## Summary

Closes the last two flag-surface parity gaps identified by the audit against Python pre-commit:

- `pre-commit uninstall -t pre-commit -t pre-push` now uninstalls both hook types in one invocation (Python uses `action='append'`).
- `pre-commit init-templatedir -t pre-commit -t pre-push <dir>` writes both hook scripts.

Both commands previously accepted only a single `-t` value (Go: `string` with default `"pre-commit"`), which silently dropped extra `-t` flags.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test -race ./internal/cli/`
- [ ] Manual: `pre-commit uninstall -t pre-commit -t pre-push` removes both
- [ ] Manual: `pre-commit init-templatedir -t pre-commit -t commit-msg /tmp/td` writes both scripts under `/tmp/td/hooks/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)