### PR TITLE
fix: prevent host-repo corruption from leaked git env during hooks

### DIFF
--- a/internal/cli/hook_impl.go
+++ b/internal/cli/hook_impl.go
@@ -10,6 +10,7 @@ import (
 
 	flags "github.com/jessevdk/go-flags"
 
+	"github.com/blairham/go-pre-commit/v4/internal/git"
 	"github.com/blairham/go-pre-commit/v4/internal/output"
 )
 
@@ -29,6 +30,12 @@ type hookImplFlags struct {
 }
 
 func (c *HookImplCommand) Run(args []string) int {
+	// Invoked by git from within a commit/checkout/etc., so GIT_DIR,
+	// GIT_INDEX_FILE and GIT_WORK_TREE point at the host repo. Clear them up front
+	// so no child git process (e.g. a hook-repo clone) can inherit them and
+	// corrupt the host index/object store. See git.ScrubProcessEnv.
+	git.ScrubProcessEnv()
+
 	var opts hookImplFlags
 	remaining, err := flags.NewParser(&opts, flags.HelpFlag|flags.PassDoubleDash).ParseArgs(args)
 	if err != nil {

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -52,6 +52,11 @@ type runFlags struct {
 }
 
 func (c *RunCommand) Run(args []string) int {
+	// Backstop in case `run` is reached directly from a git-invoked hook (not via
+	// hook-impl): drop the host repo's GIT_DIR/GIT_INDEX_FILE/GIT_WORK_TREE so no
+	// child git process can corrupt the host repo. See git.ScrubProcessEnv.
+	git.ScrubProcessEnv()
+
 	var opts runFlags
 	opts.Jobs = runtime.NumCPU()
 

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -41,6 +41,26 @@ func NoGitEnv() []string {
 	return env
 }
 
+// ScrubProcessEnv clears the git-managed environment variables that git exports
+// when it invokes a hook (GIT_DIR, GIT_INDEX_FILE, GIT_WORK_TREE). They point at
+// the *host* repo. If any child git process inherits them — a clone, a checkout,
+// a goroutine-spawned command, or anything that forgets NoGitEnv() — it operates
+// on the host repo instead of its own and corrupts the host index/object store
+// (e.g. a hook-repo clone whose checkout lands entries in the host's index,
+// producing "fatal: unable to read <object>").
+//
+// NoGitEnv() scrubs these per command, but call this once at hook entry as a
+// belt-and-suspenders backstop so the leak is impossible regardless of the exec
+// path. This only affects this hook process and its children; the parent
+// `git commit` retains its own copy and completes normally. The stash and
+// staged-file commands keep working because they discover the worktree's index
+// from the working directory once GIT_INDEX_FILE is gone.
+func ScrubProcessEnv() {
+	for _, k := range []string{"GIT_DIR", "GIT_INDEX_FILE", "GIT_WORK_TREE"} {
+		_ = os.Unsetenv(k)
+	}
+}
+
 // CmdOutput runs a git command and returns its stdout.
 func CmdOutput(args ...string) (string, error) {
 	cmd := exec.Command("git", args...)
@@ -72,6 +92,7 @@ func CmdOutputInDir(dir string, args ...string) (string, error) {
 func RunInDir(dir string, args ...string) error {
 	cmd := exec.Command("git", args...)
 	cmd.Dir = dir
+	cmd.Env = NoGitEnv()
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	return cmd.Run()
@@ -187,6 +208,12 @@ func Clone(url, dest string, args ...string) error {
 	cmdArgs = append(cmdArgs, args...)
 	cmdArgs = append(cmdArgs, url, dest)
 	cmd := exec.Command("git", cmdArgs...)
+	// Scrub GIT_* env (esp. GIT_DIR/GIT_INDEX_FILE/GIT_WORK_TREE that git exports
+	// when invoking a hook). Without this, `git clone` run from inside a
+	// commit-triggered hook "clones the wrong thing" — the checkout writes index
+	// entries referencing the cloned repo's objects into the HOST repo's index,
+	// corrupting it ("fatal: unable to read <object>"). See NoGitEnv() above.
+	cmd.Env = NoGitEnv()
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	return cmd.Run()
@@ -288,6 +315,7 @@ func StashPop(dir string) error {
 func CheckoutIndex(dir, dest string) error {
 	cmd := exec.Command("git", "checkout-index", "-a", "--prefix="+dest+"/")
 	cmd.Dir = dir
+	cmd.Env = NoGitEnv()
 	return cmd.Run()
 }
 

--- a/internal/git/git_test.go
+++ b/internal/git/git_test.go
@@ -80,6 +80,30 @@ func TestNoGitEnv(t *testing.T) {
 	}
 }
 
+// TestScrubProcessEnv is a regression test for host-repo corruption: git exports
+// GIT_DIR/GIT_INDEX_FILE/GIT_WORK_TREE (pointing at the host repo) when it invokes
+// a hook. If a child git process — e.g. a hook-repo clone — inherits them it writes
+// into the host repo's index/object store and corrupts it ("fatal: unable to read
+// <object>"). hook-impl calls ScrubProcessEnv at entry so the leak is impossible
+// regardless of which exec path runs.
+func TestScrubProcessEnv(t *testing.T) {
+	t.Setenv("GIT_DIR", "/host/.git")
+	t.Setenv("GIT_INDEX_FILE", "/host/.git/index")
+	t.Setenv("GIT_WORK_TREE", "/host")
+	t.Setenv("GIT_AUTHOR_NAME", "keep-me") // not host-scoped; must survive
+
+	ScrubProcessEnv()
+
+	for _, k := range []string{"GIT_DIR", "GIT_INDEX_FILE", "GIT_WORK_TREE"} {
+		if v, ok := os.LookupEnv(k); ok {
+			t.Errorf("ScrubProcessEnv should unset %s, but it is still set to %q", k, v)
+		}
+	}
+	if os.Getenv("GIT_AUTHOR_NAME") != "keep-me" {
+		t.Error("ScrubProcessEnv should not touch non-host-scoped GIT_ vars")
+	}
+}
+
 func TestNoGitEnv_AllowedVars(t *testing.T) {
 	// Allowed GIT_ vars should be preserved.
 	t.Setenv("GIT_SSH", "ssh-custom")

--- a/internal/staged/staged.go
+++ b/internal/staged/staged.go
@@ -52,6 +52,7 @@ func (m *Manager) StashUnstaged() (bool, error) {
 	// requires the trailing newline to be present).
 	diffCmd := exec.Command("git", "diff")
 	diffCmd.Dir = m.dir
+	diffCmd.Env = git.NoGitEnv()
 	diffOut, err := diffCmd.Output()
 	if err != nil {
 		return false, fmt.Errorf("generating diff: %w", err)
@@ -75,13 +76,17 @@ func (m *Manager) StashUnstaged() (bool, error) {
 		args := append([]string{"rm", "--cached", "--"}, intentFiles...)
 		cmd := exec.Command("git", args...)
 		cmd.Dir = m.dir
+		cmd.Env = git.NoGitEnv()
 		_ = cmd.Run()
 	}
 
-	// Checkout the index (staged-only content) — set env to prevent post-checkout firing.
+	// Checkout the index (staged-only content). Scrub GIT_* (NoGitEnv) so the
+	// host repo's GIT_DIR/GIT_INDEX_FILE — exported by git when it invokes this
+	// hook — don't redirect checkout-index at the commit-time index; set the
+	// post-checkout skip flag on top of the scrubbed env.
 	cmd := exec.Command("git", "checkout-index", "--all", "--force")
 	cmd.Dir = m.dir
-	cmd.Env = append(os.Environ(), "_PRE_COMMIT_SKIP_POST_CHECKOUT=1")
+	cmd.Env = append(git.NoGitEnv(), "_PRE_COMMIT_SKIP_POST_CHECKOUT=1")
 	if err := cmd.Run(); err != nil {
 		// Clean up patch file on error.
 		os.Remove(m.patchPath)
@@ -115,6 +120,7 @@ func (m *Manager) Restore() error {
 			// Fall back to checkout approach.
 			cmd := exec.Command("git", "checkout", "--", ".")
 			cmd.Dir = m.dir
+			cmd.Env = git.NoGitEnv()
 			_ = cmd.Run()
 		}
 	}
@@ -122,10 +128,12 @@ func (m *Manager) Restore() error {
 	// Apply the patch to restore unstaged changes.
 	cmd := exec.Command("git", "apply", "--allow-empty", m.patchPath)
 	cmd.Dir = m.dir
+	cmd.Env = git.NoGitEnv()
 	if err := cmd.Run(); err != nil {
 		// If direct apply fails, try 3-way merge.
 		cmd = exec.Command("git", "apply", "--3way", m.patchPath)
 		cmd.Dir = m.dir
+		cmd.Env = git.NoGitEnv()
 		if err := cmd.Run(); err != nil {
 			return fmt.Errorf("restoring unstaged changes (patch saved at %s): %w", m.patchPath, err)
 		}
@@ -137,6 +145,7 @@ func (m *Manager) Restore() error {
 		args := append([]string{"add", "--intent-to-add", "--"}, intentFiles...)
 		cmd := exec.Command("git", args...)
 		cmd.Dir = m.dir
+		cmd.Env = git.NoGitEnv()
 		_ = cmd.Run()
 	}
 


### PR DESCRIPTION
Fixes #29.

## Problem

When `pre-commit` runs as a git hook, git exports `GIT_DIR` / `GIT_INDEX_FILE` / `GIT_WORK_TREE` pointing at the **host** repo. Not all git invocations scrubbed them, so a hook-repo **clone** during a commit could inherit `GIT_INDEX_FILE` and write the cloned repo's files into the host repo's index → `fatal: unable to read <object>`, and `git status`/`git commit` then fail. This is real host-repo data corruption.

## Root cause

`NoGitEnv()` exists exactly to strip these (mirrors Python pre-commit's `no_git_env()`), but it wasn't applied to `RunInDir`, `Clone`, `CheckoutIndex`, or the raw `exec.Command` calls in `internal/staged/staged.go`. The bug is timing-sensitive — slowing any git call (tracing, a wrapper, a tty) masks it — so it only bites under real load.

## Fix

- **`git.ScrubProcessEnv()`** — clears `GIT_DIR`/`GIT_INDEX_FILE`/`GIT_WORK_TREE` once at `hook-impl` and `run` entry. Belt-and-suspenders: no child git process can inherit them regardless of which exec path runs. Only affects the hook process; the parent `git commit` keeps its own copy and completes normally; the stash/staged-file commands rediscover the worktree index from the cwd.
- Apply **`NoGitEnv()`** to the remaining unscrubbed calls: `RunInDir`, `Clone`, `CheckoutIndex`, and the raw `git` commands in `staged.go`.
- **Regression test** for `ScrubProcessEnv`.

## Verification

Repro: a commit that needs to clone a not-yet-installed hook repo + an unstaged change (stash path), run at full speed.

| Build | Host repo corrupted |
|---|---|
| before | 100% (breaks on attempt 1, every run) |
| after | 0% over 120 runs |

`go test ./...` passes (13 packages); touched packages pass with `-race`.